### PR TITLE
Create a channel class as a wrapper for subjects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,11 @@
       <version>4.11</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.reactivex.rxjava3</groupId>
+      <artifactId>rxjava</artifactId>
+      <version>3.1.1</version>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/src/main/java/com/alvarium/exampleapp/App.java
+++ b/src/main/java/com/alvarium/exampleapp/App.java
@@ -1,6 +1,8 @@
 package com.alvarium.exampleapp;
 
 import com.alvarium.SdkInfo;
+import com.alvarium.exampleapp.observers.Channel;
+
 import config.Reader;
 import config.ReaderException;
 import config.ReaderFactory;
@@ -11,6 +13,11 @@ public class App{
     ReaderFactory factory = new ReaderFactory();
     Reader reader = factory.getReader(ReaderType.JSON);
     SdkInfo sdkInfo = reader.read("./src/main/resources/config.json");
+
+    final Channel<SampleData> createChannel = new Channel<SampleData>();
+    final Channel<SampleData> mutateChannel = new Channel<SampleData>();
+    final Channel<SampleData> transitChannel = new Channel<SampleData>();
+
   }
 
 }

--- a/src/main/java/com/alvarium/exampleapp/observers/Channel.java
+++ b/src/main/java/com/alvarium/exampleapp/observers/Channel.java
@@ -1,0 +1,44 @@
+package com.alvarium.exampleapp.observers;
+
+import io.reactivex.rxjava3.core.Observer;
+import io.reactivex.rxjava3.subjects.PublishSubject;
+
+/**
+ * Creates a channel of communication using the observer pattern.
+ * 
+ * The main objective of this class is to be a wrapper around subjects for better member naming and
+ * also to protect additional subject methods.
+ * 
+ * This class takes a generic type which is used to infer the type of data this channel will hold.
+ */
+public class Channel<T>{
+  private PublishSubject<T> subject;
+
+  public Channel() {
+    subject = PublishSubject.create();
+  }
+
+  /**
+   * Subscribes an observer to this channel, meaning that this observer will now trigger its onNext
+   * whenever a new message is emmited on this channel
+   * @param observer
+   */
+  public void registerObserver(Observer<T> observer) {
+    subject.subscribe(observer);
+  }
+
+  /**
+   * Add a new message to this channel
+   * @param data
+   */
+  public void publish(T data) {
+    subject.onNext(data);
+  }
+
+  /**
+   * Close and remove any allocated resources by this channel
+   */
+  public void close() {
+    subject.onComplete();
+  }
+}

--- a/src/test/java/com/alvarium/exampleapp/observers/ChannelTest.java
+++ b/src/test/java/com/alvarium/exampleapp/observers/ChannelTest.java
@@ -1,0 +1,34 @@
+package com.alvarium.exampleapp.observers;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava3.core.Observer;
+import io.reactivex.rxjava3.disposables.Disposable;
+
+public class ChannelTest {
+  class MockObserver implements Observer<Integer> {
+    private Boolean triggered = false;
+    public void onNext(Integer value) {
+      triggered = true;
+    }
+    public void onError(Throwable t) {}
+    public void onComplete() {}
+    public void onSubscribe(Disposable d) {}
+    public Boolean wasTriggered() {
+      return triggered;
+    }
+  }
+
+  @Test
+  public void channelPublishShouldTriggerObserver() {
+    final Channel<Integer> channel = new Channel<Integer>();
+    MockObserver observer = new MockObserver();
+    channel.registerObserver(observer);
+    channel.publish(1);
+    channel.close();
+    assertTrue(observer.wasTriggered());
+  }
+  
+}


### PR DESCRIPTION
Fix #12

* Implement Channel class to abstract subject methods
* Create unit tests
* Instantiate channels ready for the create, mutate, and transit observers

Signed-off-by: Ali Amin <ali.m.amin98@gmail.com>