### PR TITLE
Add Mutate Observer which calls the sdk.mutate() method

### DIFF
--- a/src/main/java/com/alvarium/exampleapp/App.java
+++ b/src/main/java/com/alvarium/exampleapp/App.java
@@ -25,6 +25,7 @@ import com.alvarium.exampleapp.observers.CreationObserver;
 import com.alvarium.sign.KeyInfo;
 import com.alvarium.sign.SignException;
 import com.alvarium.exampleapp.observers.TransitionObserver;
+import com.alvarium.exampleapp.observers.MutationObserver;
 import com.alvarium.annotators.Annotator;
 import com.alvarium.annotators.AnnotatorException;
 import com.alvarium.annotators.AnnotatorFactory;
@@ -76,10 +77,15 @@ public class App {
     transitionChannel.registerObserver(transitionObserver);
 
     // Get keyInfo to generate new sample data
-    final KeyInfo keyInfo = new KeyInfo(
-      sdkInfo.getSignature().getPrivateKey().getPath(),
-      sdkInfo.getSignature().getPrivateKey().getType()
+    final KeyInfo keyInfo = sdkInfo.getSignature().getPrivateKey();
+    
+
+    final Observer<SampleData> mutationObserver = new MutationObserver(
+      sdk, 
+      keyInfo, 
+      transitionChannel
     );
+    mutationChannel.registerObserver(mutationObserver);
 
     final Timer timer = new Timer();
     final TimerTask generateData = new TimerTask() {

--- a/src/main/java/com/alvarium/exampleapp/observers/MutationObserver.java
+++ b/src/main/java/com/alvarium/exampleapp/observers/MutationObserver.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright 2021 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package com.alvarium.exampleapp.observers;
+
+import java.io.IOException;
+
+import com.alvarium.Sdk;
+import com.alvarium.annotators.AnnotatorException;
+import com.alvarium.exampleapp.SampleData;
+import com.alvarium.sign.KeyInfo;
+import com.alvarium.sign.SignException;
+import com.alvarium.streams.StreamException;
+
+import io.reactivex.rxjava3.core.Observer;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.exceptions.Exceptions;
+
+public class MutationObserver implements Observer<SampleData>{
+  private final Sdk sdk;
+  private final KeyInfo keyInfo;
+
+  private final Channel<SampleData> destinationChannel; 
+
+  public MutationObserver(Sdk sdk, KeyInfo keyInfo,Channel<SampleData> destinationChannel) {
+    this.sdk = sdk;
+    this.keyInfo=keyInfo;
+    this.destinationChannel = destinationChannel;
+  } 
+
+  public void onNext(SampleData oldData) {
+    try {
+      SampleData sampleData = new SampleData(keyInfo);
+      sdk.mutate(oldData.toJson().getBytes(), sampleData.toJson().getBytes());
+      destinationChannel.publish(sampleData);
+    } catch(AnnotatorException e) {
+      Exceptions.propagate(
+          new ObserverException("Could not annotate data during mutate", e)
+      );
+    } catch(StreamException e) {
+      Exceptions.propagate(
+          new ObserverException("Could not publish data during mutate", e)
+      );
+    }catch(SignException e) {
+      Exceptions.propagate(
+          new ObserverException("Could not sign sample data", e)
+      );
+  }catch(IOException e) {
+    Exceptions.propagate(
+        new ObserverException("Could not read key", e)
+    );
+  }
+  }
+
+  @Override
+  public void onError(Throwable d) {
+    final Exception e = new Exception(d);
+    Exceptions.propagate(
+        new ObserverException("Could not publish data during mutate", e)
+    );
+  }
+
+  @Override
+  public void onComplete() {}
+
+  @Override
+  public void onSubscribe(Disposable d) {}
+
+}

--- a/src/test/java/com/alvarium/exampleapp/observers/MutationObserverTest.java
+++ b/src/test/java/com/alvarium/exampleapp/observers/MutationObserverTest.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright 2021 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package com.alvarium.exampleapp.observers;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+import com.alvarium.Sdk;
+import com.alvarium.SdkInfo;
+import com.alvarium.exampleapp.SampleData;
+import com.alvarium.sign.KeyInfo;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import config.Reader;
+import config.ReaderFactory;
+import config.ReaderType;
+import io.reactivex.rxjava3.core.Observer;
+
+public class MutationObserverTest {
+  @Test
+  public void mutationObserverShouldMutateAndPublish() throws Exception{
+    
+    Channel<SampleData> srcChannel = new Channel<SampleData>();
+    Channel<SampleData> destinationChannel =new Channel<SampleData>();
+    final Sdk sdk = Mockito.mock(Sdk.class);
+    ReaderFactory readerFactory = new ReaderFactory();
+    Reader reader = readerFactory.getReader(ReaderType.JSON);
+
+    SdkInfo sdkInfo = reader.read("./src/main/resources/config.json");
+    final KeyInfo keyInfo = sdkInfo.getSignature().getPrivateKey();
+
+    final SampleData oldData = new SampleData(keyInfo);
+
+    final Observer<SampleData> mutationObserver = new MutationObserver(sdk,keyInfo,destinationChannel);
+    srcChannel.registerObserver(mutationObserver);
+    srcChannel.publish(oldData);
+    
+    //Using any() because mutate generates its own sample data as the new data
+    //and Mockito checks argument equality 
+    verify(sdk).mutate(any(byte[].class),any(byte[].class));
+
+    
+
+  }
+  
+}


### PR DESCRIPTION
Fix #16

* Implemented mutation observer
* Add unit tests
* Subscribe the observer to the mutation channel

Signed-off-by: Amina Yasser <aminayasser00@gmail.com>